### PR TITLE
Fix VP calculation bug and changing wait time calculation

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -1,4 +1,4 @@
-categories = ['bid bot abuse',
+CATEGORIES = ['bid bot abuse',
               'collusive voting',
               'comment self-vote violation',
               'comment spam',
@@ -15,7 +15,7 @@ categories = ['bid bot abuse',
               'testing for rewards',
               'threat',
               'vote abuse',
-              'vote farming']  # Because the categories are sorted alphabetically, comment spam will be found before spam is, causing everything to work out as intended.  # Because the categories are sorted alphabetically, comment spam will be found before spam is, causing everything to work out as intended.
+              'vote farming']  # Because the categories are sorted alphabetically, comment spam will be found before spam is, causing everything to work out as intended.
 
 CAT_DESCRIPTION = {'bid bot abuse' : '\n* bid bot abuse\nYou bought votes to increase the rewards of your post above the value of its content.',
                    'collusive voting' : '\ndescription placeholder',

--- a/sfrbot.py
+++ b/sfrbot.py
@@ -1,4 +1,4 @@
-from categories import CAT_DESCRIPTION, CAT_LIST
+from categories import CAT_DESCRIPTION, CATEGORIES
 import asyncio
 import datetime
 import logging
@@ -43,7 +43,7 @@ queue_vp = 95
 def check_cat(comment):
     """Returning the matching category of abuse"""
     cats = []
-    for cat in CAT_LIST:
+    for cat in CATEGORIES:
         if cat in comment.lower():
             if cat == 'spam' and 'comment spam' in comment.lower():
                 continue

--- a/sfrbot.py
+++ b/sfrbot.py
@@ -12,7 +12,7 @@ from beem.comment import Comment
 from beem.exceptions import AccountDoesNotExistsException, ContentDoesNotExistsException, VotingInvalidOnArchivedPost
 from beem.instance import set_shared_steem_instance
 from beem.nodelist import NodeList
-from beem.utils import construct_authorperm, reputation_to_score
+from beem.utils import construct_authorperm, reputation_to_score, addTzInfo
 from dateutil.parser import parse
 from discord.ext.commands import Bot
 
@@ -29,6 +29,7 @@ set_shared_steem_instance(stm)
 queueing = False
 queue_vp = 95
 
+STEEM_MIN_REPLY_INTERVAL = 20  # TODO: change to 3s once HF20 is active
 
 ##################################################
 # Uncomment for the initial setup of the database
@@ -52,15 +53,12 @@ def check_cat(comment):
 
 
 def get_wait_time(account):
-    """Preventing unability to comment, because of STEEM_MIN_REPLY_INTERVAL. Only works for one 'queued' comment."""
-    for i in account.history_reverse(only_ops='comment'):
-        if i['author'] == account['name']:
-            wait = datetime.datetime.utcnow() - parse(i['timestamp'])
-            wait = wait.seconds
-            if wait > 20:  # TODO: Change to 3 once HF20 is out
-                return 0
-            else:
-                return 20 - wait  # TODO: Change to 3 once HF20 is out as well
+    """Get the time (in seconds) required until the next comment can be posted.
+    Only works for one 'queued' comment.
+    """
+    account.refresh()
+    last_post_timedelta = addTzInfo(datetime.datetime.utcnow()) - account['last_post']
+    return max(0, STEEM_MIN_REPLY_INTERVAL - last_post_timedelta.total_seconds())
 
 
 def report():

--- a/sfrbot.py
+++ b/sfrbot.py
@@ -224,11 +224,16 @@ async def approve(ctx, link):
             if not cursor.execute('SELECT flagger FROM steemflagrewards WHERE flagger == ?;', (flagger.name,)):
                 ROI += first_flag_ROI
 
+            if queueing:
+                voting_power = queue_vp * 100
+            else:
+                voting_power = sfr.get_voting_power() * 100
             vote_pct = stm.rshares_to_vote_pct(int(abs(int(v['rshares'])) * ROI),  # ROI for the flaggers
                                                steem_power=sfr.sp,
-                                               voting_power=queue_vp if queueing else sfr.get_voting_power() * 100)
-            min_vote_pct = stm.rshares_to_vote_pct(0.0245 / stm.get_sbd_per_rshares(), steem_power=sfr.sp,
-                                                   voting_power=queue_vp if queueing else sfr.get_voting_power() * 100)
+                                               voting_power=voting_power)
+            min_vote_pct = stm.rshares_to_vote_pct(0.0245 / stm.get_sbd_per_rshares(),
+                                                   steem_power=sfr.sp,
+                                                   voting_power=voting_power)
             weight = max(round((vote_pct / 10000) * 100), round((min_vote_pct / 10000) * 100))
     if sfr.get_vote(flaggers_comment):
         await ctx.send('Already voted on this!')


### PR DESCRIPTION
* the problem with 100% votes when the bot was in queuing-mode was caused by a missing multiplication by `100` for the `voting_power` argument to `rshares_to_vote_pct` - The bot voted like it's VP was 0.95% instead of like 95%.
* minor fix on the categories: `CAT_LIST` was renamed to `categories` in a67ab5d602baacfeed55771516bd0fc30e0057d2 but not updated in `sfrbot.py`; duplicated comment removed
* changed implementation of `get_wait_time()` from parsing the account history to using the `last_post` field in the Account information. This is done in the same way as Steem does: https://github.com/steemit/steem/blob/27db90b11ee031d3157f5e3ec9835a5938088daf/libraries/chain/steem_evaluator.cpp#L732